### PR TITLE
Readme typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ Version 4.1.0 focuses on improved library internal implementation and C++ standa
 #### HFL
  - Improve Readme
  - Improve example level code to prevent save/load bug and use modern features of Outpost2DLL
- - Improve C++ standards compliance and readbility of source code
+ - Improve C++ standards compliance and readability of source code
  - Remove excessive internal casting
 
 ### Version 4.0.0

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ The following submodules are included:
 Follows semantic versioning: https://semver.org/
 
 ### Version 4.1.0
-Version 4.1.0 focuses on focuses on improved library internal implementation and C++ standards compliance. A few minor enhancements are made in OP2Helper including a BuildingBays enum. the constant AllPlayers in Outpost2DLL is now deprecated and should be replaced by PlayerNum::PlayerAll. Targeting a specific version of the Windows SDK was removed from all three major libraries. 
+Version 4.1.0 focuses on improved library internal implementation and C++ standards compliance. A few minor enhancements are made in OP2Helper including a BuildingBays enum. the constant AllPlayers in Outpost2DLL is now deprecated and should be replaced by PlayerNum::PlayerAll. Targeting a specific version of the Windows SDK was removed from all three major libraries. 
 
 #### Outpost2DLL
  - Bug: Fix documentation of RecordVehReinforceGroup to prevent a hanging bug within Outpost2.exe


### PR DESCRIPTION
My plan is to release this version without the major HFL updates as an enhancement (4.1.0). I think the next release after this will be 5.0.0 as I updated a couple of existing function names in HFL that are public.